### PR TITLE
Add One Dimensional Bar

### DIFF
--- a/Swift Charts Examples.xcodeproj/project.pbxproj
+++ b/Swift Charts Examples.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		2E5763C628576B1B006C7C36 /* PyramidChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5763C528576B1B006C7C36 /* PyramidChart.swift */; };
 		88B3E5D02857493B00840CAA /* RangeSimple.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B3E5CF2857493B00840CAA /* RangeSimple.swift */; };
+		934A95042857D035009E29F4 /* OneDimensionalBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934A95032857D035009E29F4 /* OneDimensionalBar.swift */; };
 		C22EB59E28568D0B000B9F9A /* Swift_Charts_ExamplesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22EB59D28568D0B000B9F9A /* Swift_Charts_ExamplesApp.swift */; };
 		C22EB5A028568D0B000B9F9A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22EB59F28568D0B000B9F9A /* ContentView.swift */; };
 		C22EB5A228568D0C000B9F9A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C22EB5A128568D0C000B9F9A /* Assets.xcassets */; };
@@ -48,6 +49,7 @@
 		262541172856A35B00A1E2EC /* Build.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Build.xcconfig; sourceTree = "<group>"; };
 		2E5763C528576B1B006C7C36 /* PyramidChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyramidChart.swift; sourceTree = "<group>"; };
 		88B3E5CF2857493B00840CAA /* RangeSimple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeSimple.swift; sourceTree = "<group>"; };
+		934A95032857D035009E29F4 /* OneDimensionalBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDimensionalBar.swift; sourceTree = "<group>"; };
 		C22EB59A28568D0B000B9F9A /* Swift Charts Examples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Swift Charts Examples.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C22EB59D28568D0B000B9F9A /* Swift_Charts_ExamplesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Swift_Charts_ExamplesApp.swift; sourceTree = "<group>"; };
 		C22EB59F28568D0B000B9F9A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -101,7 +103,7 @@
 				2E5763C528576B1B006C7C36 /* PyramidChart.swift */,
 			);
 			path = Pyramid;
-      sourceTree = "<group>";
+			sourceTree = "<group>";
 		};
 		88B3E5CC285748E400840CAA /* RangeCharts */ = {
 			isa = PBXGroup;
@@ -232,6 +234,7 @@
 				2E5763C428576B0C006C7C36 /* Pyramid */,
 				C260882C2856B4B900B09DDB /* Simple */,
 				C260881E2856A33300B09DDB /* Two Bars */,
+				934A95032857D035009E29F4 /* OneDimensionalBar.swift */,
 			);
 			path = BarCharts;
 			sourceTree = "<group>";
@@ -407,6 +410,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C26088252856A45800B09DDB /* Square.swift in Sources */,
+				934A95042857D035009E29F4 /* OneDimensionalBar.swift in Sources */,
 				C260882B2856B3C500B09DDB /* AreaSimple.swift in Sources */,
 				88B3E5D02857493B00840CAA /* RangeSimple.swift in Sources */,
 				C22EB5A028568D0B000B9F9A /* ContentView.swift in Sources */,

--- a/Swift Charts Examples/Charts/BarCharts/OneDimensionalBar.swift
+++ b/Swift Charts Examples/Charts/BarCharts/OneDimensionalBar.swift
@@ -1,0 +1,101 @@
+//
+// Copyright © 2022 Swift Charts Examples.
+// Open Source - MIT License
+
+import SwiftUI
+import Charts
+
+struct OneDimensionalBarSimpleOverview: View {
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("One Dimensional Bar")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Chart(DataUsageData.example, id: \.category) { element in
+                BarMark(
+                    x: .value("Data Size", element.size)
+                )
+                .foregroundStyle(by: .value("Data Category", element.category))
+            }
+            .chartPlotStyle { plotArea in
+                plotArea
+                    .background(Color(.systemFill))
+                    .cornerRadius(8)
+            }
+            .chartXScale(range: 0...128)
+            .chartXAxis(.hidden)
+            .chartYAxis(.hidden)
+            .chartLegend(.hidden)
+            .frame(height: Constants.previewChartHeight)
+        }
+    }
+}
+
+struct OneDimensionalBarOverview_Previews: PreviewProvider {
+    static var previews: some View {
+        OneDimensionalBarSimpleOverview()
+            .padding()
+    }
+}
+
+struct OneDimensionalBarSimpleDetailView: View {
+    @State private var showLegend = true
+    
+    var totalSize: Double {
+        return DataUsageData
+            .example
+            .reduce(0) { $0 + $1.size }
+    }
+
+    var body: some View {
+        List {
+            Section {
+                VStack {
+                    HStack {
+                        Text("iPhone")
+                        Spacer()
+                        Text("\(totalSize, specifier: "%.1f") GB of 128 GB Used")
+                            .foregroundColor(.secondary)
+                    }
+
+                    Chart(DataUsageData.example, id: \.category) { element in
+                        BarMark(
+                            x: .value("Data Size", element.size)
+                        )
+                        .foregroundStyle(by: .value("Data Category", element.category))
+                        .accessibilityLabel(element.category)
+                        .accessibilityValue("\(element.size, specifier: "%.1f")")
+                    }
+                    .chartPlotStyle { plotArea in
+                        plotArea
+                            .background(Color(.systemFill))
+                            .cornerRadius(8)
+                    }
+                    .chartXScale(range: 0...128)
+                    .chartYScale(range: .plotDimension(endPadding: -8))
+                    .chartLegend(showLegend ? .visible : .hidden)
+                    .chartLegend(position: .bottom, spacing: -8)
+                    .frame(height: 64)
+                }
+            }
+            
+            customisation
+        }
+
+        .navigationBarTitle("One Dimensional Bar", displayMode: .inline)
+    }
+    
+    
+    private var customisation: some View {
+        Section {
+            Toggle("Show Chart Legend", isOn: $showLegend)
+        }
+    }
+}
+
+struct OneDimensionalBarDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        OneDimensionalBarSimpleDetailView()
+    }
+}

--- a/Swift Charts Examples/ContentView.swift
+++ b/Swift Charts Examples/ContentView.swift
@@ -41,6 +41,8 @@ struct ContentView: View {
                     SingleBarDetailView()
                 case .twoBars:
                     TwoBarsSimpleDetailView()
+                case .oneDimensionalBar:
+                    OneDimensionalBarSimpleDetailView()
                 case .pyramid:
                     PyramidChartDetailView()
                 case .areaSimple:

--- a/Swift Charts Examples/Data/Data.swift
+++ b/Swift Charts Examples/Data/Data.swift
@@ -200,3 +200,26 @@ struct PopulationByAgeData {
         ]),
     ]
 }
+
+struct DataUsageData {
+    /// A data series for the bars.
+    struct Series: Identifiable {
+        /// Data Group.
+        let category: String
+
+        /// Size of data in gigabytes?
+        let size: Double
+
+        /// The identifier for the series.
+        var id: String { category }
+    }
+    
+    static let example: [Series] = [
+        .init(category: "Apps", size: 61.6),
+        .init(category: "Photos", size: 8.2),
+        .init(category: "iOS", size: 5.7),
+        .init(category: "System Data", size: 2.6)
+//        .init(category: "Photos", size: )
+        
+    ]
+}

--- a/Swift Charts Examples/Model/ChartType.swift
+++ b/Swift Charts Examples/Model/ChartType.swift
@@ -23,6 +23,7 @@ enum ChartType: String, Identifiable, CaseIterable {
     case singleBar
     case twoBars
     case pyramid
+    case oneDimensionalBar
     
     // Area Charts
     case areaSimple
@@ -42,6 +43,8 @@ enum ChartType: String, Identifiable, CaseIterable {
             return "Two Bars"
         case .pyramid:
             return "Pyramid"
+        case .oneDimensionalBar:
+            return "One Dimensional Bar"
         case .areaSimple:
             return "Simple Area"
         case .rangeSimple:
@@ -56,6 +59,8 @@ enum ChartType: String, Identifiable, CaseIterable {
         case .singleBar:
             return .bar
         case .twoBars:
+            return .bar
+        case .oneDimensionalBar:
             return .bar
         case .pyramid:
             return .bar
@@ -75,6 +80,8 @@ enum ChartType: String, Identifiable, CaseIterable {
             BarChartSimpleOverview()
         case .twoBars:
             TwoBarsSimpleOverview()
+        case .oneDimensionalBar:
+            OneDimensionalBarSimpleOverview()
         case .pyramid:
             PyramidChartOverview()
         case .areaSimple:


### PR DESCRIPTION
Adds a One Dimensional Bar chart similar to the Data Usage charts on Mac/iOS.

Detail view is styled after the iOS data usage page.

![Simulator Screen Shot - iPhone 13 Pro Max - 2022-06-14 at 08 52 59](https://user-images.githubusercontent.com/422836/173443417-2dfae825-013a-4afd-912c-ed0710525d7c.png)