### PR TITLE
Format PyramidChart's X axis labels

### DIFF
--- a/Swift Charts Examples/Charts/BarCharts/Pyramid/PyramidChart.swift
+++ b/Swift Charts Examples/Charts/BarCharts/Pyramid/PyramidChart.swift
@@ -61,9 +61,12 @@ struct PyramidChartDetailView: View {
                 }
             }
             .chartXAxis {
-                AxisMarks(preset: .aligned, position: .automatic) { _ in
+                AxisMarks(preset: .aligned, position: .automatic) { value in
+                    let rawValue = value.as(Int.self)!
+                    let percentage = abs(Double(rawValue) / 100)
+                    
                     AxisGridLine()
-                    AxisValueLabel()
+                    AxisValueLabel(percentage.formatted(.percent))
                 }
             }
             .chartLegend(position: .top, alignment: .center)


### PR DESCRIPTION
Updated @panpapryk’s Pyramid Chart to show absolute values on the X-axis, as suggested in [original PR](https://github.com/jordibruin/SwiftChartExamples/pull/10). 

![Simulator Screen Shot - iPhone 13 - 2022-06-13 at 15 32 05](https://user-images.githubusercontent.com/1015356/173458438-e9364ba1-4753-421b-a9f7-52448b282669.png)
