### PR TITLE
Remove x and y axis of customizeable heat map

### DIFF
--- a/Swift Charts Examples/Charts/HeatMap/HeatMapCustomization.swift
+++ b/Swift Charts Examples/Charts/HeatMap/HeatMapCustomization.swift
@@ -40,18 +40,18 @@ struct CustomizableHeatMapDetail: View {
                 }
             }
             
-            GeometryReader { geo in
-                Chart(grid.points, id: \.self) { point in
-                    RectangleMark(
-                        xStart: PlottableValue.value("xStart", point.x),
-                        xEnd: PlottableValue.value("xEnd", point.x + 1),
-                        yStart: PlottableValue.value("yStart", point.y),
-                        yEnd: PlottableValue.value("yEnd", point.y + 1)
-                    )
-                    .foregroundStyle(by: .value("Value", point.val))
-                }
+            Chart(grid.points, id: \.self) { point in
+                RectangleMark(
+                    xStart: PlottableValue.value("xStart", point.x),
+                    xEnd: PlottableValue.value("xEnd", point.x + 1),
+                    yStart: PlottableValue.value("yStart", point.y),
+                    yEnd: PlottableValue.value("yEnd", point.y + 1)
+                )
+                .foregroundStyle(by: .value("Value", point.val))
             }
         }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
         .padding()
         .onAppear {
             grid.generateData()


### PR DESCRIPTION
Attempted to solve https://github.com/jordibruin/SwiftChartExamples/issues/22 by creating custom ranges for x and y axis, but was not successful. Removing x and y axis solved the problem though. 
![Simulator Screen Shot - iPhone 13 Pro - 2022-06-13 at 18 56 04](https://user-images.githubusercontent.com/55256366/173466016-90f32260-b00a-4200-bc65-58a17f520781.png)

