### PR TITLE
Put customization tools into list

### DIFF
--- a/Swift Charts Examples/Charts/HeatMap/HeatMapCustomization.swift
+++ b/Swift Charts Examples/Charts/HeatMap/HeatMapCustomization.swift
@@ -49,6 +49,9 @@ struct CustomizableHeatMapDetail: View {
                 )
                 .foregroundStyle(by: .value("Value", point.val))
             }
+            .chartXAxis(.hidden)
+            .chartYAxis(.hidden)
+            
         }
         .chartXAxis(.hidden)
         .chartYAxis(.hidden)

--- a/Swift Charts Examples/Charts/HeatMap/HeatMapCustomization.swift
+++ b/Swift Charts Examples/Charts/HeatMap/HeatMapCustomization.swift
@@ -14,48 +14,49 @@ struct CustomizableHeatMapDetail: View {
     var body: some View {
         
         VStack {
-            VStack {
-                Stepper {
-                    Text("Rows: \(numRows)")
-                } onIncrement: {
-                    numRows += 1
-                    grid = Grid(numRows: numRows, numCols: numCols)
-                    grid.generateData()
-                } onDecrement: {
-                    numRows -= 1
-                    grid = Grid(numRows: numRows, numCols: numCols)
-                    grid.generateData()
+            List {
+                Section {
+                    Chart(grid.points, id: \.self) { point in
+                        RectangleMark(
+                            xStart: PlottableValue.value("xStart", point.x),
+                            xEnd: PlottableValue.value("xEnd", point.x + 1),
+                            yStart: PlottableValue.value("yStart", point.y),
+                            yEnd: PlottableValue.value("yEnd", point.y + 1)
+                        )
+                        .foregroundStyle(by: .value("Value", point.val))
+                    }
+                    .chartXAxis(.hidden)
+                    .chartYAxis(.hidden)
                 }
-                
-                Stepper {
-                    Text("Columns: \(numCols)")
-                } onIncrement: {
-                    numCols += 1
-                    grid = Grid(numRows: numRows, numCols: numCols)
-                    grid.generateData()
-                } onDecrement: {
-                    numCols -= 1
-                    grid = Grid(numRows: numRows, numCols: numCols)
-                    grid.generateData()
+                .frame(height: 300)
+                Section {
+                    Stepper {
+                        Text("Rows: \(numRows)")
+                    } onIncrement: {
+                        numRows += 1
+                        grid = Grid(numRows: numRows, numCols: numCols)
+                        grid.generateData()
+                    } onDecrement: {
+                        numRows -= 1
+                        grid = Grid(numRows: numRows, numCols: numCols)
+                        grid.generateData()
+                    }
+                    
+                    Stepper {
+                        Text("Columns: \(numCols)")
+                    } onIncrement: {
+                        numCols += 1
+                        grid = Grid(numRows: numRows, numCols: numCols)
+                        grid.generateData()
+                    } onDecrement: {
+                        numCols -= 1
+                        grid = Grid(numRows: numRows, numCols: numCols)
+                        grid.generateData()
+                    }
                 }
             }
-            
-            Chart(grid.points, id: \.self) { point in
-                RectangleMark(
-                    xStart: PlottableValue.value("xStart", point.x),
-                    xEnd: PlottableValue.value("xEnd", point.x + 1),
-                    yStart: PlottableValue.value("yStart", point.y),
-                    yEnd: PlottableValue.value("yEnd", point.y + 1)
-                )
-                .foregroundStyle(by: .value("Value", point.val))
-            }
-            .chartXAxis(.hidden)
-            .chartYAxis(.hidden)
-            
+
         }
-        .chartXAxis(.hidden)
-        .chartYAxis(.hidden)
-        .padding()
         .onAppear {
             grid.generateData()
         }

--- a/Swift Charts Examples/Model/ChartType.swift
+++ b/Swift Charts Examples/Model/ChartType.swift
@@ -136,6 +136,5 @@ enum ChartType: String, Identifiable, CaseIterable {
         case .heatMapMultiColor:
             HeatMapMultiColorDetailView()
         }
-        
     }
 }


### PR DESCRIPTION
I also attempted to add color options, but foreground color, accent color, etc. would not work. The only way I know to make it multicolor is the example that was just merged in (using a style and opacity). Because it is already implemented (and my example relies on a different style), I did not add it to my example.

![Simulator Screen Shot - iPhone 13 Pro - 2022-06-13 at 19 32 57](https://user-images.githubusercontent.com/55256366/173469236-ccf1aadc-db98-402a-91aa-1fcfb2559c43.png)
