### PR TITLE
Fix bar chart customisations and navigation titles 📊

### DIFF
--- a/Swift Charts Examples/Charts/BarCharts/Simple/SingleBar.swift
+++ b/Swift Charts Examples/Charts/BarCharts/Simple/SingleBar.swift
@@ -6,9 +6,7 @@ import SwiftUI
 import Charts
 
 struct SingleBarDetailView: View {
-    
-    @State private var lineWidth = 2.0
-    @State private var interpolationMethod: ChartInterpolationMethod = .cardinal
+    @State private var barWidth = 7.0
     @State private var chartColor: Color = .blue
     
     var body: some View {
@@ -17,34 +15,28 @@ struct SingleBarDetailView: View {
                 Chart(SalesData.last30Days, id: \.day) {
                     BarMark(
                         x: .value("Date", $0.day),
-                        y: .value("Sales", $0.sales)
+                        y: .value("Sales", $0.sales),
+                        width: .fixed(barWidth)
                     )
-                    .lineStyle(StrokeStyle(lineWidth: lineWidth))
                     .foregroundStyle(chartColor)
-                    .interpolationMethod(interpolationMethod.mode)
                 }
                 .frame(height: Constants.detailChartHeight)
             }
             
             customisation
         }
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitle("Single Bar", displayMode: .inline)
     }
     
     private var customisation: some View {
         Section {
-            Stepper(value: $lineWidth, in: 1.0...20.0) {
+            Stepper(value: $barWidth, in: 1.0...20.0) {
                 HStack {
-                    Text("Line Width")
+                    Text("Bar Width")
                     Spacer()
-                    Text("\(String(format: "%.0f",lineWidth))")
+                    Text("\(String(format: "%.0f", barWidth))")
                 }
             }
-            
-            Picker("Interpolation Method", selection: $interpolationMethod) {
-                ForEach(ChartInterpolationMethod.allCases) { Text($0.mode.description).tag($0) }
-            }
-            
             ColorPicker("Color Picker", selection: $chartColor)
         }
     }

--- a/Swift Charts Examples/Charts/BarCharts/Two Bars/TwoBars.swift
+++ b/Swift Charts Examples/Charts/BarCharts/Two Bars/TwoBars.swift
@@ -42,7 +42,7 @@ struct TwoBarsOverview_Previews: PreviewProvider {
 }
 
 struct TwoBarsSimpleDetailView: View {
-    @State private var lineWidth = 2.0
+    @State private var barWidth = 13.0
     @State private var interpolationMethod: ChartInterpolationMethod = .cardinal
     @State private var strideBy: ChartStrideBy = .day
     @State private var showLegend = false
@@ -55,7 +55,8 @@ struct TwoBarsSimpleDetailView: View {
                     ForEach(series.sales, id: \.weekday) { element in
                         BarMark(
                             x: .value("Day", element.weekday, unit: .day),
-                            y: .value("Sales", element.sales)
+                            y: .value("Sales", element.sales),
+                            width: .fixed(barWidth)
                         )
                         .accessibilityLabel("\(element.weekday.formatted())")
                         .accessibilityValue("\(element.sales)")
@@ -79,18 +80,17 @@ struct TwoBarsSimpleDetailView: View {
             
             customisation
         }
-
         .navigationBarTitle("Two Bars", displayMode: .inline)
     }
     
     
     private var customisation: some View {
         Section {
-            Stepper(value: $lineWidth, in: 1.0...20.0) {
+            Stepper(value: $barWidth, in: 1.0...20.0) {
                 HStack {
-                    Text("Line Width")
+                    Text("Bar Width")
                     Spacer()
-                    Text("\(String(format: "%.0f",lineWidth))")
+                    Text("\(String(format: "%.0f", barWidth))")
                 }
             }
             


### PR DESCRIPTION
The single and two bars charts had `lineWidth` that did nothing, these have been updated to `barWidth` to control the bar width.

Interpolation mode was on the single bar chart that also did nothing, this was removed.

The navigation title was not set for the single bar chart, so it was showing as large display mode. This has also been fixed.